### PR TITLE
Fix calculated rewards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+.next*

--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -65,10 +65,15 @@ const Results: React.FC<ResultsProps> = ({
     (a, b) => b.points_sum - a.points_sum,
   );
 
-  const totalTokensAllocated = contributors.reduce(
-    (sum, contributor) => sum + (contributor.tokensAllocated || 0),
-    0,
-  );
+  const phase22orLater = phaseId && phaseId >= 22;
+  // For all contributor allocations starting at phase 22, reduce contributor total rewards from 95 to 65k DEXTR.
+  const contributorAllocationFix = phase22orLater ? 65 / 95 : 1;
+  const totalTokensAllocated =
+    contributors.reduce(
+      (sum, contributor) => sum + (contributor.tokensAllocated || 0),
+      0,
+    ) * contributorAllocationFix; // fix contributor token allocation
+
   const formattedTotalTokensAllocated = totalTokensAllocated.toLocaleString();
 
   const wsUri = 'wss://dexternominations.space';
@@ -293,10 +298,12 @@ const Results: React.FC<ResultsProps> = ({
                   <td className="whitespace-nowrap px-6 py-4 text-right">
                     <span className="text-sm md:text-base font-normal">
                       {' '}
-                      {Number(contributor.tokensAllocated).toLocaleString(
-                        undefined,
-                        { minimumFractionDigits: 2, maximumFractionDigits: 2 },
-                      )}{' '}
+                      {Number(
+                        contributor.tokensAllocated * contributorAllocationFix,
+                      ).toLocaleString(undefined, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}{' '}
                     </span>
                     <span className="text-sm"> DEXTR</span>{' '}
                   </td>

--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -330,6 +330,38 @@ const Results: React.FC<ResultsProps> = ({
                 <th></th>
                 <th>
                   <span className="font-lexend font-normal text-sm md:text-base  md:mr-5">
+                    Liquidity Incentives:
+                  </span>
+                </th>
+                <th className="px-6 py-2 text-sm md:text-base font-normal md:font-semibold">
+                  {' '}
+                  20,000{' '}
+                  <span className="text-sm md:text-base font-normal">
+                    {' '}
+                    DEXTR
+                  </span>{' '}
+                </th>
+              </tr>
+              <tr>
+                <th></th>
+                <th>
+                  <span className="font-lexend font-normal text-sm md:text-base  md:mr-5">
+                    Validator Node Stakers:
+                  </span>
+                </th>
+                <th className="px-6 py-2 text-sm md:text-base font-normal md:font-semibold">
+                  {' '}
+                  10,000{' '}
+                  <span className="text-sm md:text-base font-normal">
+                    {' '}
+                    DEXTR
+                  </span>{' '}
+                </th>
+              </tr>
+              <tr>
+                <th></th>
+                <th>
+                  <span className="font-lexend font-normal text-sm md:text-base  md:mr-5">
                     Reserve Allocation:
                   </span>
                 </th>


### PR DESCRIPTION
Please merge https://github.com/DeXter-on-Radix/voting-app/pull/3 first

The allocations in the results page are currently not calculated correctly, as it still calculats with a 95'000 DEXTR contributor allocations instead of 65'000. This leads to a higher amount being displayed as there will actually be payed out, which is not a nice contributor experience :P 

This issue was reported multiple times from the community, e.g.:
![image](https://github.com/DeXter-on-Radix/voting-app/assets/44790691/ed6bca81-bdc5-445f-b470-e8c8c8702ae5)


This PR adds a hotfix to display correct amounts by introducing the folliwing changes:
- reduced contributor rewards to 65k
- addapted calculations
- added trading and staking allocations to overview.

![image](https://github.com/DeXter-on-Radix/voting-app/assets/44790691/58104da2-fcfc-4a3b-ab5b-670783db9372)
